### PR TITLE
Explicitly require active_support classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,10 @@ activate :releases do |releases|
   # releases.new_release_template = File.expand_path('../custom_template.tt', __FILE__)
 end
 ```
+
+If your date frontmatter includes timestamps, you should also ensure a
+`Time.zone` is being set in your `config.rb`:
+
+```ruby
+Time.zone = 'America/New_York'
+```

--- a/lib/releases/instance.rb
+++ b/lib/releases/instance.rb
@@ -1,3 +1,7 @@
+require 'active_support/time_with_zone'
+require 'active_support/core_ext/time/acts_like'
+require 'active_support/core_ext/time/calculations'
+
 module Releases
   class Instance
     extend Forwardable

--- a/middleman-releases.gemspec
+++ b/middleman-releases.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   # The version of middleman-core your extension depends on
   s.add_runtime_dependency("middleman-core", [">= 4.0.0"])
+  s.add_runtime_dependency("activesupport", ">= 4.2")
 
   # Additional dependencies
   # s.add_runtime_dependency("gem-name", "gem-version")


### PR DESCRIPTION
Previously, our project was using the `middleman-blog` plugin, which uses these `active_support` classes to calculate timezone information.

When we removed the plugin, these classes were not being loaded and made our Middleman site build fail.

Explicitly loading these classes solves this issue.